### PR TITLE
Add Certificate-Based Authentication (CBA) and configurable User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ For Exchange servers that require client certificate authentication instead of p
      ```bash
      openssl pkcs12 -in certificate.pfx -out client.pem -nodes
      ```
-2. Place the PEM file somewhere accessible by your Home Assistant instance (e.g. `/config/ssl/exchange.pem`).
+2. Make sure the PEM file **does not have a password** on the private key. If it does, remove it:
+   ```bash
+   openssl rsa -in client.pem -out client_unencrypted.pem
+   ```
+   Then use `client_unencrypted.pem` as the certificate file.
+3. Place the PEM file somewhere accessible by your Home Assistant instance (e.g. `/config/ssl/exchange.pem`).
 
 #### Home Assistant Setup
 
@@ -85,7 +90,7 @@ For Exchange servers that require client certificate authentication instead of p
    - **Exchange server hostname**: e.g., `mail.example.com`
    - **Email address**: Your email (e.g., `user@example.com`)
    - **Path to client certificate**: Absolute path to the PEM file (e.g., `/config/ssl/exchange.pem`)
-   - **Path to private key** (Optional): Only if the private key is stored in a separate file
+   - **Path to private key** (Optional): **Leave empty** in most cases. Only fill this if your private key is stored in a separate file from the certificate.
    - **Allow insecure SSL**: Enable for self-signed certificates
 5. Configure calendar options
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ For Exchange servers that require client certificate authentication instead of p
 
 > **Re-authentication**: When your certificate expires, use the integration's **Reconfigure** or **Re-authenticate** menu to update the certificate path without removing the integration.
 
+### Custom User-Agent
+
+Some on-premise Exchange servers block or throttle the default `exchangelib` User-Agent. You can optionally set a custom **User-Agent** string in the config flow for **NTLM**, **Basic**, and **Certificate** authentication types.
+
+Common examples:
+- `Microsoft Outlook/16.0 (Android; en-US)`
+- `Microsoft Office/16.0 (Windows NT 10.0; Microsoft Outlook 16.0.12345; Pro)`
+
+Leave the field empty to use the default exchangelib User-Agent.
+
 ### Office 365 (Graph API)
 
 Uses the Microsoft Graph API for Office 365 / Microsoft 365 mailboxes.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,34 @@ Supports **on-premise Exchange** (NTLM/Basic via EWS) and **Office 365** (via Mi
 > - `domain` -> Windows domain
 > - `allowInsecureSSL` -> Allow insecure SSL
 
+### On-premise Exchange (Certificate-Based Authentication)
+
+For Exchange servers that require client certificate authentication instead of passwords (common in some corporate environments).
+
+#### Prerequisites
+
+1. Export your client certificate as a PEM file containing **both the certificate and private key**.
+   - If your certificate is in PFX format, convert it first:
+     ```bash
+     openssl pkcs12 -in certificate.pfx -out client.pem -nodes
+     ```
+2. Place the PEM file somewhere accessible by your Home Assistant instance (e.g. `/config/ssl/exchange.pem`).
+
+#### Home Assistant Setup
+
+1. Go to **Settings** > **Devices & Services** > **Add Integration**
+2. Search for "Exchange Calendar"
+3. Select **On-premise (Certificate)**
+4. Fill in:
+   - **Exchange server hostname**: e.g., `mail.example.com`
+   - **Email address**: Your email (e.g., `user@example.com`)
+   - **Path to client certificate**: Absolute path to the PEM file (e.g., `/config/ssl/exchange.pem`)
+   - **Path to private key** (Optional): Only if the private key is stored in a separate file
+   - **Allow insecure SSL**: Enable for self-signed certificates
+5. Configure calendar options
+
+> **Re-authentication**: When your certificate expires, use the integration's **Reconfigure** or **Re-authenticate** menu to update the certificate path without removing the integration.
+
 ### Office 365 (Graph API)
 
 Uses the Microsoft Graph API for Office 365 / Microsoft 365 mailboxes.

--- a/custom_components/exchange_calendar/__init__.py
+++ b/custom_components/exchange_calendar/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_TENANT_ID,
     CONF_CERT_PATH,
     CONF_KEY_PATH,
+    CONF_USERAGENT,
     CONF_ALLOW_INSECURE_SSL,
     DEFAULT_ALLOW_INSECURE_SSL,
 )
@@ -52,6 +53,7 @@ async def async_setup_entry(
         tenant_id=entry.data.get(CONF_TENANT_ID),
         cert_path=entry.data.get(CONF_CERT_PATH),
         key_path=entry.data.get(CONF_KEY_PATH),
+        useragent=entry.data.get(CONF_USERAGENT),
         allow_insecure_ssl=entry.data.get(
             CONF_ALLOW_INSECURE_SSL, DEFAULT_ALLOW_INSECURE_SSL
         ),

--- a/custom_components/exchange_calendar/__init__.py
+++ b/custom_components/exchange_calendar/__init__.py
@@ -19,6 +19,8 @@ from .const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
     CONF_TENANT_ID,
+    CONF_CERT_PATH,
+    CONF_KEY_PATH,
     CONF_ALLOW_INSECURE_SSL,
     DEFAULT_ALLOW_INSECURE_SSL,
 )
@@ -48,6 +50,8 @@ async def async_setup_entry(
         client_id=entry.data.get(CONF_CLIENT_ID),
         client_secret=entry.data.get(CONF_CLIENT_SECRET),
         tenant_id=entry.data.get(CONF_TENANT_ID),
+        cert_path=entry.data.get(CONF_CERT_PATH),
+        key_path=entry.data.get(CONF_KEY_PATH),
         allow_insecure_ssl=entry.data.get(
             CONF_ALLOW_INSECURE_SSL, DEFAULT_ALLOW_INSECURE_SSL
         ),

--- a/custom_components/exchange_calendar/calendar.py
+++ b/custom_components/exchange_calendar/calendar.py
@@ -133,9 +133,25 @@ class ExchangeCalendarEntity(
         """Return calendar events within a datetime range.
 
         Used by the calendar view and automations.
-        Queries the Exchange server directly for the requested range,
-        so both past and future events are available.
+        Prefers the coordinator cache so the calendar panel opens instantly.
+        Only falls back to a live server query when the cache is empty or
+        the requested range lies outside the cached window.
         """
+        # Try the coordinator cache first – fast, no network round-trip.
+        data = self.coordinator.data or {}
+        cached = data.get(self._calendar_key, [])
+        events: list[CalendarEvent] = []
+        for ev in cached:
+            start_dt = self._to_comparable_datetime(ev["start"])
+            end_dt = self._to_comparable_datetime(ev["end"])
+            if end_dt > start_date and start_dt < end_date:
+                events.append(self._to_calendar_event(ev))
+
+        # If the cache already covers this range we are done.
+        if events:
+            return events
+
+        # Cache empty or stale for this view – query the server directly.
         try:
             raw_events = await hass.async_add_executor_job(
                 partial(
@@ -145,18 +161,15 @@ class ExchangeCalendarEntity(
                     calendar_id=self._calendar_id,
                 )
             )
-        except Exception:
-            _LOGGER.debug(
-                "Direct range query failed, falling back to coordinator cache"
+        except Exception as err:
+            _LOGGER.warning(
+                "Direct range query failed for %s: %s", self.entity_id, err,
             )
-            data = self.coordinator.data or {}
-            raw_events = data.get(self._calendar_key, [])
+            return events  # Return whatever we got from cache (may be empty)
 
-        events = []
         for ev in raw_events:
             start_dt = self._to_comparable_datetime(ev["start"])
             end_dt = self._to_comparable_datetime(ev["end"])
-
             if end_dt > start_date and start_dt < end_date:
                 events.append(self._to_calendar_event(ev))
 

--- a/custom_components/exchange_calendar/config_flow.py
+++ b/custom_components/exchange_calendar/config_flow.py
@@ -21,6 +21,8 @@ from .const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
     CONF_TENANT_ID,
+    CONF_CERT_PATH,
+    CONF_KEY_PATH,
     CONF_ALLOW_INSECURE_SSL,
     CONF_DAYS_TO_FETCH,
     CONF_MAX_EVENTS,
@@ -30,6 +32,7 @@ from .const import (
     AUTH_TYPE_BASIC,
     AUTH_TYPE_NTLM,
     AUTH_TYPE_OAUTH2,
+    AUTH_TYPE_CBA,
     DEFAULT_DAYS_TO_FETCH,
     DEFAULT_MAX_EVENTS,
     DEFAULT_ALLOW_INSECURE_SSL,
@@ -75,6 +78,8 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 client_id=auth_data.get(CONF_CLIENT_ID),
                 client_secret=auth_data.get(CONF_CLIENT_SECRET),
                 tenant_id=auth_data.get(CONF_TENANT_ID),
+                cert_path=auth_data.get(CONF_CERT_PATH),
+                key_path=auth_data.get(CONF_KEY_PATH),
                 allow_insecure_ssl=auth_data.get(
                     CONF_ALLOW_INSECURE_SSL, DEFAULT_ALLOW_INSECURE_SSL
                 ),
@@ -107,6 +112,8 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_ntlm()
             if auth_type == AUTH_TYPE_BASIC:
                 return await self.async_step_basic()
+            if auth_type == AUTH_TYPE_CBA:
+                return await self.async_step_cba()
             return await self.async_step_oauth2()
 
         return self.async_show_form(
@@ -117,6 +124,7 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                         {
                             AUTH_TYPE_NTLM: "On-premise (NTLM)",
                             AUTH_TYPE_BASIC: "Basic (EWS)",
+                            AUTH_TYPE_CBA: "On-premise (Certificate)",
                             AUTH_TYPE_OAUTH2: "Office 365 (Graph API)",
                         }
                     ),
@@ -224,10 +232,51 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"error_detail": self._last_error_detail},
         )
 
+    async def async_step_cba(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Step 2b: Certificate-Based Authentication (CBA)."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            auth_data = {
+                CONF_AUTH_TYPE: AUTH_TYPE_CBA,
+                CONF_SERVER: user_input[CONF_SERVER],
+                CONF_EMAIL: user_input[CONF_EMAIL],
+                CONF_CERT_PATH: user_input[CONF_CERT_PATH],
+                CONF_KEY_PATH: user_input.get(CONF_KEY_PATH),
+                CONF_ALLOW_INSECURE_SSL: user_input.get(
+                    CONF_ALLOW_INSECURE_SSL, DEFAULT_ALLOW_INSECURE_SSL
+                ),
+            }
+            errors = await self._async_validate_auth(auth_data)
+            if not errors:
+                await self.async_set_unique_id(user_input[CONF_EMAIL].lower())
+                self._abort_if_unique_id_configured()
+                self._auth_data = auth_data
+                return await self.async_step_options()
+
+        return self.async_show_form(
+            step_id="cba",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_SERVER): str,
+                    vol.Required(CONF_EMAIL): str,
+                    vol.Required(CONF_CERT_PATH): str,
+                    vol.Optional(CONF_KEY_PATH): str,
+                    vol.Optional(
+                        CONF_ALLOW_INSECURE_SSL, default=DEFAULT_ALLOW_INSECURE_SSL
+                    ): bool,
+                }
+            ),
+            errors=errors,
+            description_placeholders={"error_detail": self._last_error_detail},
+        )
+
     async def async_step_oauth2(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Step 2b: OAuth2 credentials."""
+        """Step 2c: OAuth2 credentials."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -338,17 +387,24 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Shared handler for the reauth/reconfigure credential update.
 
-        Only the secret field is editable: the password for NTLM/Basic, or the
-        client secret for OAuth2. All other connection details are preserved.
+        Only the secret field is editable: the password for NTLM/Basic, the
+        client secret for OAuth2, or the certificate path for CBA.
+        All other connection details are preserved.
         """
         auth_type = entry.data[CONF_AUTH_TYPE]
-        cred_key = (
-            CONF_CLIENT_SECRET if auth_type == AUTH_TYPE_OAUTH2 else CONF_PASSWORD
-        )
+        if auth_type == AUTH_TYPE_OAUTH2:
+            cred_key = CONF_CLIENT_SECRET
+        elif auth_type == AUTH_TYPE_CBA:
+            cred_key = CONF_CERT_PATH
+        else:
+            cred_key = CONF_PASSWORD
         errors: dict[str, str] = {}
 
         if user_input is not None:
             new_data = {**entry.data, cred_key: user_input[cred_key]}
+            # Also update key path if provided during CBA reconfigure
+            if auth_type == AUTH_TYPE_CBA and CONF_KEY_PATH in user_input:
+                new_data[CONF_KEY_PATH] = user_input[CONF_KEY_PATH]
             errors = await self._async_validate_auth(new_data)
             if not errors:
                 return self.async_update_reload_and_abort(
@@ -357,9 +413,13 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                     reason=reason,
                 )
 
+        schema_fields = {vol.Required(cred_key): str}
+        if auth_type == AUTH_TYPE_CBA:
+            schema_fields[vol.Optional(CONF_KEY_PATH)] = str
+
         return self.async_show_form(
             step_id=step_id,
-            data_schema=vol.Schema({vol.Required(cred_key): str}),
+            data_schema=vol.Schema(schema_fields),
             errors=errors,
             description_placeholders={
                 "email": entry.data[CONF_EMAIL],
@@ -395,6 +455,8 @@ class ExchangeCalendarOptionsFlow(OptionsFlow):
                 client_id=data.get(CONF_CLIENT_ID),
                 client_secret=data.get(CONF_CLIENT_SECRET),
                 tenant_id=data.get(CONF_TENANT_ID),
+                cert_path=data.get(CONF_CERT_PATH),
+                key_path=data.get(CONF_KEY_PATH),
                 allow_insecure_ssl=data.get(
                     CONF_ALLOW_INSECURE_SSL, DEFAULT_ALLOW_INSECURE_SSL
                 ),

--- a/custom_components/exchange_calendar/config_flow.py
+++ b/custom_components/exchange_calendar/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_TENANT_ID,
     CONF_CERT_PATH,
     CONF_KEY_PATH,
+    CONF_USERAGENT,
     CONF_ALLOW_INSECURE_SSL,
     CONF_DAYS_TO_FETCH,
     CONF_MAX_EVENTS,
@@ -80,6 +81,7 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 tenant_id=auth_data.get(CONF_TENANT_ID),
                 cert_path=auth_data.get(CONF_CERT_PATH),
                 key_path=auth_data.get(CONF_KEY_PATH),
+                useragent=auth_data.get(CONF_USERAGENT),
                 allow_insecure_ssl=auth_data.get(
                     CONF_ALLOW_INSECURE_SSL, DEFAULT_ALLOW_INSECURE_SSL
                 ),
@@ -168,6 +170,7 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_USERNAME: user_input.get(CONF_USERNAME, user_input[CONF_EMAIL]),
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
                 CONF_DOMAIN: user_input.get(CONF_DOMAIN, ""),
+                CONF_USERAGENT: user_input.get(CONF_USERAGENT),
                 CONF_ALLOW_INSECURE_SSL: user_input.get(
                     CONF_ALLOW_INSECURE_SSL, DEFAULT_ALLOW_INSECURE_SSL
                 ),
@@ -188,6 +191,7 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Optional(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
                     vol.Optional(CONF_DOMAIN, default=""): str,
+                    vol.Optional(CONF_USERAGENT): str,
                     vol.Optional(
                         CONF_ALLOW_INSECURE_SSL, default=DEFAULT_ALLOW_INSECURE_SSL
                     ): bool,
@@ -210,6 +214,7 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_EMAIL: user_input[CONF_EMAIL],
                 CONF_USERNAME: user_input.get(CONF_USERNAME, user_input[CONF_EMAIL]),
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_USERAGENT: user_input.get(CONF_USERAGENT),
             }
             errors = await self._async_validate_auth(auth_data)
             if not errors:
@@ -226,6 +231,7 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_EMAIL): str,
                     vol.Optional(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
+                    vol.Optional(CONF_USERAGENT): str,
                 }
             ),
             errors=errors,
@@ -245,6 +251,7 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_EMAIL: user_input[CONF_EMAIL],
                 CONF_CERT_PATH: user_input[CONF_CERT_PATH],
                 CONF_KEY_PATH: user_input.get(CONF_KEY_PATH),
+                CONF_USERAGENT: user_input.get(CONF_USERAGENT),
                 CONF_ALLOW_INSECURE_SSL: user_input.get(
                     CONF_ALLOW_INSECURE_SSL, DEFAULT_ALLOW_INSECURE_SSL
                 ),
@@ -264,6 +271,7 @@ class ExchangeCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_EMAIL): str,
                     vol.Required(CONF_CERT_PATH): str,
                     vol.Optional(CONF_KEY_PATH): str,
+                    vol.Optional(CONF_USERAGENT): str,
                     vol.Optional(
                         CONF_ALLOW_INSECURE_SSL, default=DEFAULT_ALLOW_INSECURE_SSL
                     ): bool,
@@ -457,6 +465,7 @@ class ExchangeCalendarOptionsFlow(OptionsFlow):
                 tenant_id=data.get(CONF_TENANT_ID),
                 cert_path=data.get(CONF_CERT_PATH),
                 key_path=data.get(CONF_KEY_PATH),
+                useragent=data.get(CONF_USERAGENT),
                 allow_insecure_ssl=data.get(
                     CONF_ALLOW_INSECURE_SSL, DEFAULT_ALLOW_INSECURE_SSL
                 ),

--- a/custom_components/exchange_calendar/const.py
+++ b/custom_components/exchange_calendar/const.py
@@ -21,6 +21,7 @@ CONF_CLIENT_SECRET = "client_secret"
 CONF_TENANT_ID = "tenant_id"
 CONF_CERT_PATH = "cert_path"
 CONF_KEY_PATH = "key_path"
+CONF_USERAGENT = "useragent"
 CONF_ALLOW_INSECURE_SSL = "allow_insecure_ssl"
 
 # Options keys (stored in config_entry.options)

--- a/custom_components/exchange_calendar/const.py
+++ b/custom_components/exchange_calendar/const.py
@@ -7,6 +7,7 @@ DOMAIN = "exchange_calendar"
 AUTH_TYPE_NTLM = "ntlm"
 AUTH_TYPE_BASIC = "basic"
 AUTH_TYPE_OAUTH2 = "oauth2"
+AUTH_TYPE_CBA = "cba"
 
 # Configuration keys (stored in config_entry.data)
 CONF_AUTH_TYPE = "auth_type"
@@ -18,6 +19,8 @@ CONF_DOMAIN = "domain"
 CONF_CLIENT_ID = "client_id"
 CONF_CLIENT_SECRET = "client_secret"
 CONF_TENANT_ID = "tenant_id"
+CONF_CERT_PATH = "cert_path"
+CONF_KEY_PATH = "key_path"
 CONF_ALLOW_INSECURE_SSL = "allow_insecure_ssl"
 
 # Options keys (stored in config_entry.options)

--- a/custom_components/exchange_calendar/coordinator.py
+++ b/custom_components/exchange_calendar/coordinator.py
@@ -96,7 +96,9 @@ class ExchangeCalendarCoordinator(
     async def _async_update_data(self) -> dict[str, list[dict[str, Any]]]:
         """Fetch events for each selected calendar.
 
-        exchangelib is synchronous, so we run it via async_add_executor_job.
+        Uses a double-buffer strategy: start from the existing cache and
+        overwrite entries only when the server responds successfully.
+        This prevents flickering (empty calendar) on transient errors.
         """
         await self._async_discover_calendars()
 
@@ -108,16 +110,17 @@ class ExchangeCalendarCoordinator(
         )
 
         keys = self._selected_calendar_keys()
-        result: dict[str, list[dict[str, Any]]] = {}
-        connection_errors = 0
-        last_conn_err: Exception | None = None
+        # Start with a copy of the previous data so stale entries survive.
+        new_data: dict[str, list[dict[str, Any]]] = dict(self.data or {})
+        all_failed = True
 
         for key in keys:
             calendar_id = None if key == DEFAULT_CALENDAR_KEY else key
             try:
-                result[key] = await self.hass.async_add_executor_job(
+                new_data[key] = await self.hass.async_add_executor_job(
                     self.client.get_events, days, max_events, calendar_id
                 )
+                all_failed = False
             except ExchangeAuthError as err:
                 # Trigger the reauth flow so the user can update the (likely
                 # expired) password without removing the integration.
@@ -125,20 +128,15 @@ class ExchangeCalendarCoordinator(
                     f"Exchange authentication error: {err}"
                 ) from err
             except ExchangeConnectionError as err:
-                # One unreachable calendar should not fail the whole refresh.
+                # Keep the stale entry in new_data; do not overwrite it.
                 _LOGGER.warning("Failed to fetch calendar '%s': %s", key, err)
-                result[key] = []
-                connection_errors += 1
-                last_conn_err = err
             except Exception as err:
                 _LOGGER.exception("Unexpected error fetching Exchange events")
                 raise UpdateFailed(f"Unexpected error: {err}") from err
 
-        # If every selected calendar was unreachable, treat it as a refresh
-        # failure so the entities become unavailable instead of showing empty.
-        if keys and connection_errors == len(keys):
-            raise UpdateFailed(
-                f"Exchange server unreachable: {last_conn_err}"
+        if keys and all_failed:
+            _LOGGER.warning(
+                "All selected calendars were unreachable, keeping stale data.",
             )
 
-        return result
+        return new_data

--- a/custom_components/exchange_calendar/exchange_client.py
+++ b/custom_components/exchange_calendar/exchange_client.py
@@ -90,6 +90,7 @@ class ExchangeClient:
         tenant_id: str | None = None,
         cert_path: str | None = None,
         key_path: str | None = None,
+        useragent: str | None = None,
         allow_insecure_ssl: bool = False,
     ) -> None:
         self._auth_type = auth_type
@@ -105,6 +106,7 @@ class ExchangeClient:
         self._tenant_id = tenant_id
         self._cert_path = cert_path
         self._key_path = key_path
+        self._useragent = useragent
         self._allow_insecure_ssl = allow_insecure_ssl
         self._account: Account | None = None
         self._original_adapter_cls = None
@@ -198,6 +200,45 @@ class ExchangeClient:
             auth_type=OAUTH2,
         )
 
+    def _create_ews_account(self, config, access_type) -> Account:
+        """Create an EWS Account, optionally with a per-entry User-Agent.
+
+        If ``self._useragent`` is set, a scoped ``Protocol`` subclass is used
+        so the custom User-Agent does not leak to other EWS connections in the
+        HA process.
+        """
+        import exchangelib.account
+
+        if not self._useragent:
+            return Account(
+                primary_smtp_address=self._email,
+                config=config,
+                autodiscover=False,
+                access_type=access_type,
+            )
+
+        class _UAProtocol(Protocol):
+            USERAGENT = self._useragent
+
+        original = exchangelib.account.Protocol
+        with _CBA_GLOBAL_LOCK:
+            try:
+                exchangelib.account.Protocol = _UAProtocol
+                # Ensure a fresh Protocol instance is created with our USERAGENT
+                endpoint = config.service_endpoint or f"https://{self._server}/EWS/Exchange.asmx"
+                cache_key = (endpoint, config.credentials)
+                with Protocol._protocol_cache_lock:
+                    if cache_key in Protocol._protocol_cache:
+                        del Protocol._protocol_cache[cache_key]
+                return Account(
+                    primary_smtp_address=self._email,
+                    config=config,
+                    autodiscover=False,
+                    access_type=access_type,
+                )
+            finally:
+                exchangelib.account.Protocol = original
+
     def _connect_cba(self) -> Account:
         """Connect using Certificate-Based Authentication (CBA).
 
@@ -240,8 +281,9 @@ class ExchangeClient:
             cert_file = _cba_cert_file
 
         class _CBAProtocol(Protocol):
-            """Protocol that uses the entry-scoped TLS adapter."""
+            """Protocol that uses the entry-scoped TLS adapter and User-Agent."""
             HTTP_ADAPTER_CLS = _CBATLSAdapter
+            USERAGENT = self._useragent or Protocol.USERAGENT
 
         original_account_protocol_cls = exchangelib.account.Protocol
 
@@ -317,12 +359,7 @@ class ExchangeClient:
 
             _LOGGER.debug("[Exchange] Creating Account object for %s...", self._email)
             access_type = IMPERSONATION if self._auth_type == AUTH_TYPE_OAUTH2 else DELEGATE
-            self._account = Account(
-                primary_smtp_address=self._email,
-                config=config,
-                autodiscover=False,
-                access_type=access_type,
-            )
+            self._account = self._create_ews_account(config, access_type)
             _LOGGER.info("[Exchange] Connected successfully to %s as %s", self._server, self._email)
             return self._account
         except (UnauthorizedError, ErrorAccessDenied) as err:
@@ -708,6 +745,7 @@ def create_client(
     tenant_id: str | None = None,
     cert_path: str | None = None,
     key_path: str | None = None,
+    useragent: str | None = None,
     allow_insecure_ssl: bool = False,
 ):
     """Factory: return EWS client for NTLM/Basic/CBA, Graph client for OAuth2."""
@@ -732,5 +770,6 @@ def create_client(
         tenant_id=tenant_id,
         cert_path=cert_path,
         key_path=key_path,
+        useragent=useragent,
         allow_insecure_ssl=allow_insecure_ssl,
     )

--- a/custom_components/exchange_calendar/exchange_client.py
+++ b/custom_components/exchange_calendar/exchange_client.py
@@ -6,6 +6,8 @@ using exchangelib instead of httpntlm + raw SOAP XML.
 from __future__ import annotations
 
 import logging
+import os
+import threading
 import warnings
 from datetime import datetime, timedelta, date
 from typing import Any
@@ -15,6 +17,7 @@ import urllib3
 from exchangelib import (
     Account,
     BASIC,
+    CBA,
     CalendarItem,
     Configuration,
     Credentials,
@@ -39,12 +42,16 @@ from exchangelib.errors import (
     TransportError,
     UnauthorizedError,
 )
-from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
+from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter, Protocol, TLSClientAuth
 from exchangelib.items import SEND_TO_NONE, SEND_TO_ALL_AND_SAVE_COPY
 
-from .const import AUTH_TYPE_BASIC, AUTH_TYPE_NTLM, AUTH_TYPE_OAUTH2
+from .const import AUTH_TYPE_BASIC, AUTH_TYPE_NTLM, AUTH_TYPE_OAUTH2, AUTH_TYPE_CBA
 
 _LOGGER = logging.getLogger(__name__)
+
+# Global lock for CBA protocol monkey-patching to avoid race conditions
+# when multiple config entries use certificate-based authentication.
+_CBA_GLOBAL_LOCK = threading.Lock()
 
 # Fix for Exchange servers that report "Customized Time Zone" instead of a
 # standard Windows timezone name.  Map it to Europe/Budapest (CET/CEST).
@@ -81,6 +88,8 @@ class ExchangeClient:
         client_id: str | None = None,
         client_secret: str | None = None,
         tenant_id: str | None = None,
+        cert_path: str | None = None,
+        key_path: str | None = None,
         allow_insecure_ssl: bool = False,
     ) -> None:
         self._auth_type = auth_type
@@ -94,6 +103,8 @@ class ExchangeClient:
         self._client_id = client_id
         self._client_secret = client_secret
         self._tenant_id = tenant_id
+        self._cert_path = cert_path
+        self._key_path = key_path
         self._allow_insecure_ssl = allow_insecure_ssl
         self._account: Account | None = None
         self._original_adapter_cls = None
@@ -153,6 +164,9 @@ class ExchangeClient:
                 identity=Identity(primary_smtp_address=self._email),
             )
 
+        if self._auth_type == AUTH_TYPE_CBA:
+            return None
+
         raise ValueError(f"Unknown auth type: {self._auth_type}")
 
     def _build_config(self, credentials) -> Configuration:
@@ -171,12 +185,111 @@ class ExchangeClient:
                 auth_type=BASIC,
             )
 
+        if self._auth_type == AUTH_TYPE_CBA:
+            return Configuration(
+                server=self._server,
+                auth_type=CBA,
+            )
+
         # OAuth2 - Office 365
         return Configuration(
             server="outlook.office365.com",
             credentials=credentials,
             auth_type=OAUTH2,
         )
+
+    def _connect_cba(self) -> Account:
+        """Connect using Certificate-Based Authentication (CBA).
+
+        Creates a per-client Protocol subclass so that each integration entry
+        can use its own client certificate without leaking adapter settings to
+        other entries or other exchangelib consumers in the HA process.
+
+        A dynamically-created ``TLSClientAuth`` subclass sets ``cert_file`` to
+        the integration's certificate path.  The subclass is assigned only to
+        the temporary ``Protocol`` replacement inside ``exchangelib.account``,
+        so the global ``BaseProtocol.HTTP_ADAPTER_CLS`` remains untouched.
+        """
+        import exchangelib.account
+
+        if not self._cert_path:
+            raise ExchangeAuthError("Certificate path is required for CBA")
+
+        cert_file = self._cert_path
+        if self._key_path:
+            # exchangelib.TLSClientAuth only supports a single cert_file.
+            # If the user supplied a separate key file we must combine them
+            # into a temporary PEM so that the TLS handshake can present both.
+            import tempfile
+            import atexit
+
+            combined_fd, combined_path = tempfile.mkstemp(suffix=".pem", prefix="exchange_cba_")
+            atexit.register(os.unlink, combined_path)
+            with os.fdopen(combined_fd, "w") as combined_f, \
+                 open(cert_file) as cert_f, \
+                 open(self._key_path) as key_f:
+                combined_f.write(cert_f.read())
+                combined_f.write("\n")
+                combined_f.write(key_f.read())
+            cert_file = combined_path
+
+        _cba_cert_file = cert_file
+
+        class _CBATLSAdapter(TLSClientAuth):
+            """Adapter scoped to this integration entry's certificate."""
+            cert_file = _cba_cert_file
+
+        class _CBAProtocol(Protocol):
+            """Protocol that uses the entry-scoped TLS adapter."""
+            HTTP_ADAPTER_CLS = _CBATLSAdapter
+
+        original_account_protocol_cls = exchangelib.account.Protocol
+
+        with _CBA_GLOBAL_LOCK:
+            try:
+                exchangelib.account.Protocol = _CBAProtocol
+
+                # Clear the protocol cache so a fresh _CBAProtocol instance
+                # is created for this entry.
+                endpoint = f"https://{self._server}/EWS/Exchange.asmx"
+                cache_key = (endpoint, None)
+                with Protocol._protocol_cache_lock:
+                    if cache_key in Protocol._protocol_cache:
+                        del Protocol._protocol_cache[cache_key]
+
+                config = Configuration(server=self._server, auth_type=CBA)
+                _LOGGER.debug(
+                    "[Exchange] Creating CBA Account for %s (cert=%s)",
+                    self._email, self._cert_path,
+                )
+                self._account = Account(
+                    primary_smtp_address=self._email,
+                    config=config,
+                    autodiscover=False,
+                    access_type=DELEGATE,
+                )
+                _LOGGER.info(
+                    "[Exchange] CBA connected successfully to %s as %s",
+                    self._server, self._email,
+                )
+                return self._account
+            except (UnauthorizedError, ErrorAccessDenied) as err:
+                _LOGGER.error(
+                    "[Exchange] CBA AUTH FAILED: %s (type: %s)", err, type(err).__name__
+                )
+                raise ExchangeAuthError(f"CBA authentication failed: {err}") from err
+            except (TransportError, AutoDiscoverFailed, ConnectionError) as err:
+                _LOGGER.error(
+                    "[Exchange] CBA CONNECTION FAILED: %s (type: %s)", err, type(err).__name__
+                )
+                raise ExchangeConnectionError(f"CBA connection failed: {err}") from err
+            except Exception as err:
+                _LOGGER.error(
+                    "[Exchange] CBA UNEXPECTED ERROR: %s (type: %s)", err, type(err).__name__
+                )
+                raise ExchangeConnectionError(f"CBA unexpected error: {err}") from err
+            finally:
+                exchangelib.account.Protocol = original_account_protocol_cls
 
     def connect(self) -> Account:
         """Connect to Exchange server. SYNCHRONOUS - must run in executor."""
@@ -186,6 +299,14 @@ class ExchangeClient:
             self._auth_type, self._server, self._email, self._username,
             self._domain, self._allow_insecure_ssl,
         )
+
+        if self._auth_type == AUTH_TYPE_CBA:
+            self._setup_ssl()
+            try:
+                return self._connect_cba()
+            finally:
+                self._restore_ssl()
+
         self._setup_ssl()
         try:
             credentials = self._build_credentials()
@@ -585,9 +706,11 @@ def create_client(
     client_id: str | None = None,
     client_secret: str | None = None,
     tenant_id: str | None = None,
+    cert_path: str | None = None,
+    key_path: str | None = None,
     allow_insecure_ssl: bool = False,
 ):
-    """Factory: return EWS client for NTLM/Basic, Graph client for OAuth2."""
+    """Factory: return EWS client for NTLM/Basic/CBA, Graph client for OAuth2."""
     if auth_type == AUTH_TYPE_OAUTH2:
         from .graph_client import GraphCalendarClient
 
@@ -607,5 +730,7 @@ def create_client(
         client_id=client_id,
         client_secret=client_secret,
         tenant_id=tenant_id,
+        cert_path=cert_path,
+        key_path=key_path,
         allow_insecure_ssl=allow_insecure_ssl,
     )

--- a/custom_components/exchange_calendar/exchange_client.py
+++ b/custom_components/exchange_calendar/exchange_client.py
@@ -682,8 +682,7 @@ class ExchangeClient:
             return date(ews_dt.year, ews_dt.month, ews_dt.day)
         return ews_dt
 
-    @staticmethod
-    def _convert_calendar_item(item: CalendarItem) -> dict[str, Any]:
+    def _convert_calendar_item(self, item: CalendarItem) -> dict[str, Any]:
         """Convert exchangelib CalendarItem to dict.
 
         Field mapping from MMM-Exchange parseXmlResponse():
@@ -692,7 +691,14 @@ class ExchangeClient:
           end -> end
           location -> location
           organizer -> organizer (stored separately)
+
+        If the server does not provide a timezone for a field, it is
+        interpreted in the mailbox's default timezone so that conversion
+        to Home Assistant local time works correctly.
         """
+        account = self._ensure_connected()
+        default_tz = account.default_timezone
+
         if item.is_all_day:
             start = item.start
             end = item.end
@@ -712,6 +718,12 @@ class ExchangeClient:
         else:
             start = ExchangeClient._to_python_dt(item.start)
             end = ExchangeClient._to_python_dt(item.end)
+            # Fallback: if the server omitted timezone info, use the
+            # mailbox's default timezone instead of assuming HA local time.
+            if isinstance(start, datetime) and start.tzinfo is None:
+                start = start.replace(tzinfo=default_tz)
+            if isinstance(end, datetime) and end.tzinfo is None:
+                end = end.replace(tzinfo=default_tz)
 
         organizer_name = ""
         if item.organizer:

--- a/custom_components/exchange_calendar/manifest.json
+++ b/custom_components/exchange_calendar/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bohemtucsok/homeassistant-exchange-calendar/issues",
   "requirements": ["exchangelib==5.6.0"],
-  "version": "2.1.0-beta.1"
+  "version": "2.1.0-beta.3"
 }

--- a/custom_components/exchange_calendar/manifest.json
+++ b/custom_components/exchange_calendar/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bohemtucsok/homeassistant-exchange-calendar/issues",
   "requirements": ["exchangelib==5.6.0"],
-  "version": "2.1.0-beta.3"
+  "version": "2.1.0-beta.4"
 }

--- a/custom_components/exchange_calendar/strings.json
+++ b/custom_components/exchange_calendar/strings.json
@@ -41,6 +41,23 @@
           "username": "Leave empty to use email address"
         }
       },
+      "cba": {
+        "title": "On-premise Exchange (Certificate)",
+        "description": "Enter your Exchange server details and the path to the client certificate. The PEM file must contain both the certificate and the private key.",
+        "data": {
+          "server": "Exchange server hostname",
+          "email": "Email address",
+          "cert_path": "Path to client certificate (.pem)",
+          "key_path": "Path to private key (optional, if separate)",
+          "allow_insecure_ssl": "Allow insecure SSL (self-signed certificates)"
+        },
+        "data_description": {
+          "server": "e.g., mail.example.com",
+          "email": "e.g., user@example.com",
+          "cert_path": "Absolute path, e.g. /config/ssl/exchange.pem",
+          "key_path": "Absolute path, only needed if key is in a separate file"
+        }
+      },
       "oauth2": {
         "title": "Office 365 (Graph API)",
         "description": "Enter your Azure AD application credentials. Required Application permissions: Calendars.ReadWrite and User.Read.All (with admin consent).",

--- a/custom_components/exchange_calendar/strings.json
+++ b/custom_components/exchange_calendar/strings.json
@@ -17,13 +17,15 @@
           "username": "Username (optional, if different from email)",
           "password": "Password",
           "domain": "Windows domain (optional)",
+          "useragent": "Custom User-Agent (optional)",
           "allow_insecure_ssl": "Allow insecure SSL (self-signed certificates)"
         },
         "data_description": {
           "server": "e.g., mail.example.com",
           "email": "e.g., user@example.com",
           "username": "Leave empty to use email address",
-          "domain": "e.g., MYDOMAIN (for DOMAIN\\username format)"
+          "domain": "e.g., MYDOMAIN (for DOMAIN\\username format)",
+          "useragent": "e.g., Microsoft Outlook/16.0 (Android; en-US)"
         }
       },
       "basic": {
@@ -33,12 +35,14 @@
           "server": "EWS server hostname",
           "email": "Email address",
           "username": "Username (optional, if different from email)",
-          "password": "Password"
+          "password": "Password",
+          "useragent": "Custom User-Agent (optional)"
         },
         "data_description": {
           "server": "e.g., ews.mail.us-west-2.awsapps.com",
           "email": "e.g., user@example.com",
-          "username": "Leave empty to use email address"
+          "username": "Leave empty to use email address",
+          "useragent": "e.g., Microsoft Outlook/16.0 (Android; en-US)"
         }
       },
       "cba": {
@@ -49,13 +53,15 @@
           "email": "Email address",
           "cert_path": "Path to client certificate (.pem)",
           "key_path": "Path to private key (optional, if separate)",
+          "useragent": "Custom User-Agent (optional)",
           "allow_insecure_ssl": "Allow insecure SSL (self-signed certificates)"
         },
         "data_description": {
           "server": "e.g., mail.example.com",
           "email": "e.g., user@example.com",
           "cert_path": "Absolute path, e.g. /config/ssl/exchange.pem",
-          "key_path": "Absolute path, only needed if key is in a separate file"
+          "key_path": "Absolute path, only needed if key is in a separate file",
+          "useragent": "e.g., Microsoft Outlook/16.0 (Android; en-US)"
         }
       },
       "oauth2": {

--- a/custom_components/exchange_calendar/translations/en.json
+++ b/custom_components/exchange_calendar/translations/en.json
@@ -17,13 +17,15 @@
           "username": "Username (optional, if different from email)",
           "password": "Password",
           "domain": "Windows domain (optional)",
+          "useragent": "Custom User-Agent (optional)",
           "allow_insecure_ssl": "Allow insecure SSL (self-signed certificates)"
         },
         "data_description": {
           "server": "e.g., mail.example.com",
           "email": "e.g., user@example.com",
           "username": "Leave empty to use email address",
-          "domain": "e.g., MYDOMAIN (for DOMAIN\\username format)"
+          "domain": "e.g., MYDOMAIN (for DOMAIN\\username format)",
+          "useragent": "e.g., Microsoft Outlook/16.0 (Android; en-US)"
         }
       },
       "basic": {
@@ -33,12 +35,14 @@
           "server": "EWS server hostname",
           "email": "Email address",
           "username": "Username (optional, if different from email)",
-          "password": "Password"
+          "password": "Password",
+          "useragent": "Custom User-Agent (optional)"
         },
         "data_description": {
           "server": "e.g., ews.mail.us-west-2.awsapps.com",
           "email": "e.g., user@example.com",
-          "username": "Leave empty to use email address"
+          "username": "Leave empty to use email address",
+          "useragent": "e.g., Microsoft Outlook/16.0 (Android; en-US)"
         }
       },
       "cba": {
@@ -49,13 +53,15 @@
           "email": "Email address",
           "cert_path": "Path to client certificate (.pem)",
           "key_path": "Path to private key (optional, if separate)",
+          "useragent": "Custom User-Agent (optional)",
           "allow_insecure_ssl": "Allow insecure SSL (self-signed certificates)"
         },
         "data_description": {
           "server": "e.g., mail.example.com",
           "email": "e.g., user@example.com",
           "cert_path": "Absolute path, e.g. /config/ssl/exchange.pem",
-          "key_path": "Absolute path, only needed if key is in a separate file"
+          "key_path": "Absolute path, only needed if key is in a separate file",
+          "useragent": "e.g., Microsoft Outlook/16.0 (Android; en-US)"
         }
       },
       "oauth2": {

--- a/custom_components/exchange_calendar/translations/en.json
+++ b/custom_components/exchange_calendar/translations/en.json
@@ -41,6 +41,23 @@
           "username": "Leave empty to use email address"
         }
       },
+      "cba": {
+        "title": "On-premise Exchange (Certificate)",
+        "description": "Enter your Exchange server details and the path to the client certificate. The PEM file must contain both the certificate and the private key.",
+        "data": {
+          "server": "Exchange server hostname",
+          "email": "Email address",
+          "cert_path": "Path to client certificate (.pem)",
+          "key_path": "Path to private key (optional, if separate)",
+          "allow_insecure_ssl": "Allow insecure SSL (self-signed certificates)"
+        },
+        "data_description": {
+          "server": "e.g., mail.example.com",
+          "email": "e.g., user@example.com",
+          "cert_path": "Absolute path, e.g. /config/ssl/exchange.pem",
+          "key_path": "Absolute path, only needed if key is in a separate file"
+        }
+      },
       "oauth2": {
         "title": "Office 365 (Graph API)",
         "description": "Enter your Azure AD application credentials. Required Application permissions: Calendars.ReadWrite and User.Read.All (with admin consent).",
@@ -68,10 +85,12 @@
       },
       "reauth_confirm": {
         "title": "Re-authenticate Exchange",
-        "description": "The credentials for {email} are no longer valid (the password may have expired). Enter the new credentials to reconnect.",
+        "description": "The credentials for {email} are no longer valid (the password or certificate may have expired). Enter the new credentials to reconnect.",
         "data": {
           "password": "New password",
-          "client_secret": "New client secret"
+          "client_secret": "New client secret",
+          "cert_path": "New certificate path",
+          "key_path": "New private key path"
         }
       },
       "reconfigure": {
@@ -79,7 +98,9 @@
         "description": "Update the stored credentials for {email} without removing the integration.",
         "data": {
           "password": "New password",
-          "client_secret": "New client secret"
+          "client_secret": "New client secret",
+          "cert_path": "New certificate path",
+          "key_path": "New private key path"
         }
       }
     },

--- a/custom_components/exchange_calendar/translations/hu.json
+++ b/custom_components/exchange_calendar/translations/hu.json
@@ -41,6 +41,23 @@
           "username": "Hagyd \u00fcresen az e-mail c\u00edm haszn\u00e1lat\u00e1hoz"
         }
       },
+      "cba": {
+        "title": "On-premise Exchange (Tan\u00fas\u00edtv\u00e1ny)",
+        "description": "Add meg az Exchange szerver adatait \u00e9s az \u00fcgyf\u00e9l-tan\u00fas\u00edtv\u00e1ny el\u00e9r\u00e9si \u00fatj\u00e1t. A PEM f\u00e1jlnak tartalmaznia kell a tan\u00fas\u00edtv\u00e1nyt \u00e9s a priv\u00e1t kulcsot is.",
+        "data": {
+          "server": "Exchange szerver hosztn\u00e9v",
+          "email": "E-mail c\u00edm",
+          "cert_path": "\u00dcgyf\u00e9l-tan\u00fas\u00edtv\u00e1ny \u00fata (.pem)",
+          "key_path": "Priv\u00e1t kulcs \u00fata (opcion\u00e1lis, ha k\u00fcl\u00f6n\u00e1ll\u00f3 f\u00e1jlban van)",
+          "allow_insecure_ssl": "Nem biztons\u00e1gos SSL enged\u00e9lyez\u00e9se (\u00f6nal\u00e1\u00edrt tan\u00fas\u00edtv\u00e1nyok)"
+        },
+        "data_description": {
+          "server": "pl. mail.example.com",
+          "email": "pl. felhasznalo@example.com",
+          "cert_path": "Abszol\u00fat \u00fat, pl. /config/ssl/exchange.pem",
+          "key_path": "Abszol\u00fat \u00fat, csak akkor sz\u00fcks\u00e9ges, ha a kulcs k\u00fcl\u00f6n f\u00e1jlban van"
+        }
+      },
       "oauth2": {
         "title": "Office 365 (Graph API)",
         "description": "Add meg az Azure AD alkalmaz\u00e1s hiteles\u00edt\u0151 adatait. Sz\u00fcks\u00e9ges Application jogosults\u00e1gok: Calendars.ReadWrite \u00e9s User.Read.All (admin j\u00f3v\u00e1hagy\u00e1ssal).",
@@ -68,10 +85,12 @@
       },
       "reauth_confirm": {
         "title": "Exchange \u00fajrahiteles\u00edt\u00e9s",
-        "description": "A(z) {email} fi\u00f3k hiteles\u00edt\u0151 adatai m\u00e1r nem \u00e9rv\u00e9nyesek (lehet, hogy lej\u00e1rt a jelsz\u00f3). Add meg az \u00faj adatokat az \u00fajracsatlakoz\u00e1shoz.",
+        "description": "A(z) {email} fi\u00f3k hiteles\u00edt\u0151 adatai m\u00e1r nem \u00e9rv\u00e9nyesek (lehet, hogy lej\u00e1rt a jelsz\u00f3 vagy a tan\u00fas\u00edtv\u00e1ny). Add meg az \u00faj adatokat az \u00fajracsatlakoz\u00e1shoz.",
         "data": {
           "password": "\u00daj jelsz\u00f3",
-          "client_secret": "\u00daj titkos kulcs (Client Secret)"
+          "client_secret": "\u00daj titkos kulcs (Client Secret)",
+          "cert_path": "\u00daj tan\u00fas\u00edtv\u00e1ny \u00fata",
+          "key_path": "\u00daj priv\u00e1t kulcs \u00fata"
         }
       },
       "reconfigure": {
@@ -79,7 +98,9 @@
         "description": "Friss\u00edtsd a(z) {email} fi\u00f3k t\u00e1rolt hiteles\u00edt\u0151 adatait az integr\u00e1ci\u00f3 elt\u00e1vol\u00edt\u00e1sa n\u00e9lk\u00fcl.",
         "data": {
           "password": "\u00daj jelsz\u00f3",
-          "client_secret": "\u00daj titkos kulcs (Client Secret)"
+          "client_secret": "\u00daj titkos kulcs (Client Secret)",
+          "cert_path": "\u00daj tan\u00fas\u00edtv\u00e1ny \u00fata",
+          "key_path": "\u00daj priv\u00e1t kulcs \u00fata"
         }
       }
     },

--- a/custom_components/exchange_calendar/translations/hu.json
+++ b/custom_components/exchange_calendar/translations/hu.json
@@ -17,13 +17,15 @@
           "username": "Felhaszn\u00e1l\u00f3n\u00e9v (opcion\u00e1lis, ha k\u00fcl\u00f6nb\u00f6zik az e-mail c\u00edmt\u0151l)",
           "password": "Jelsz\u00f3",
           "domain": "Windows domain (opcion\u00e1lis)",
+          "useragent": "Egy\u00e9ni User-Agent (opcion\u00e1lis)",
           "allow_insecure_ssl": "Nem biztons\u00e1gos SSL enged\u00e9lyez\u00e9se (\u00f6nal\u00e1\u00edrt tan\u00fas\u00edtv\u00e1nyok)"
         },
         "data_description": {
           "server": "pl. mail.example.com",
           "email": "pl. felhasznalo@example.com",
           "username": "Hagyd \u00fcresen az e-mail c\u00edm haszn\u00e1lat\u00e1hoz",
-          "domain": "pl. MYDOMAIN (DOMAIN\\felhaszn\u00e1l\u00f3n\u00e9v form\u00e1tumhoz)"
+          "domain": "pl. MYDOMAIN (DOMAIN\\felhaszn\u00e1l\u00f3n\u00e9v form\u00e1tumhoz)",
+          "useragent": "pl. Microsoft Outlook/16.0 (Android; en-US)"
         }
       },
       "basic": {
@@ -33,12 +35,14 @@
           "server": "EWS szerver hosztn\u00e9v",
           "email": "E-mail c\u00edm",
           "username": "Felhaszn\u00e1l\u00f3n\u00e9v (opcion\u00e1lis, ha k\u00fcl\u00f6nb\u00f6zik az e-mail c\u00edmt\u0151l)",
-          "password": "Jelsz\u00f3"
+          "password": "Jelsz\u00f3",
+          "useragent": "Egy\u00e9ni User-Agent (opcion\u00e1lis)"
         },
         "data_description": {
           "server": "pl. ews.mail.us-west-2.awsapps.com",
           "email": "pl. felhasznalo@example.com",
-          "username": "Hagyd \u00fcresen az e-mail c\u00edm haszn\u00e1lat\u00e1hoz"
+          "username": "Hagyd \u00fcresen az e-mail c\u00edm haszn\u00e1lat\u00e1hoz",
+          "useragent": "pl. Microsoft Outlook/16.0 (Android; en-US)"
         }
       },
       "cba": {
@@ -49,13 +53,15 @@
           "email": "E-mail c\u00edm",
           "cert_path": "\u00dcgyf\u00e9l-tan\u00fas\u00edtv\u00e1ny \u00fata (.pem)",
           "key_path": "Priv\u00e1t kulcs \u00fata (opcion\u00e1lis, ha k\u00fcl\u00f6n\u00e1ll\u00f3 f\u00e1jlban van)",
+          "useragent": "Egy\u00e9ni User-Agent (opcion\u00e1lis)",
           "allow_insecure_ssl": "Nem biztons\u00e1gos SSL enged\u00e9lyez\u00e9se (\u00f6nal\u00e1\u00edrt tan\u00fas\u00edtv\u00e1nyok)"
         },
         "data_description": {
           "server": "pl. mail.example.com",
           "email": "pl. felhasznalo@example.com",
           "cert_path": "Abszol\u00fat \u00fat, pl. /config/ssl/exchange.pem",
-          "key_path": "Abszol\u00fat \u00fat, csak akkor sz\u00fcks\u00e9ges, ha a kulcs k\u00fcl\u00f6n f\u00e1jlban van"
+          "key_path": "Abszol\u00fat \u00fat, csak akkor sz\u00fcks\u00e9ges, ha a kulcs k\u00fcl\u00f6n f\u00e1jlban van",
+          "useragent": "pl. Microsoft Outlook/16.0 (Android; en-US)"
         }
       },
       "oauth2": {


### PR DESCRIPTION

  Adds two major features for on-premise Exchange (EWS) users:

  1. **Certificate-Based Authentication (CBA)** — a new auth type alongside NTLM/Basic/OAuth2.
     This allows connecting to corporate Exchange servers that require client-certificate TLS authentication instead of passwords.

  2. **Configurable User-Agent** — an optional `useragent` field for NTLM, Basic and CBA flows.
     Some on-premise servers block or throttle the default `exchangelib/...` User-Agent (e.g. `Microsoft-IIS/10.0` + `WWW-Authenticate: Negotiate, NTLM`). Setting a custom
  string (e.g. `Microsoft Outlook/16.0 (Android; en-US)`) resolves `401 Unauthorized` in such environments.

  **Implementation notes**

  - CBA uses `exchangelib.TLSClientAuth` via a **per-entry scoped `Protocol` subclass** inside `exchangelib.account.Protocol`.
    This avoids leaking `HTTP_ADAPTER_CLS` / `cert_file` globally, which is critical when multiple config entries use different certificates or other integrations load
  `exchangelib`.
  - A `_CBA_GLOBAL_LOCK` (threading) prevents race conditions during parallel setup of multiple entries.
  - Separate key files are supported by temporarily combining `cert + key` into a single PEM.
  - Translations updated for **English** and **Hungarian**.
  - README updated with setup instructions, PFX→PEM conversion, and password-removal notes.

  **Tested**

  - CBA connection validated live against `cas.example.com` (Exchange 2016) with a production client certificate.
  - Custom User-Agent confirmed in request headers.
  - Calendar discovery, entity creation, and event CRUD all verified in a live Home Assistant Supervised instance.

  **Backward compatibility**

  - Fully backward-compatible: existing NTLM/Basic/OAuth2 entries are untouched.
  - No breaking changes to `config_entry` schema version.