### PR TITLE
Fix calendar flickering, slow UI, and timezone fallback

### DIFF
--- a/custom_components/exchange_calendar/calendar.py
+++ b/custom_components/exchange_calendar/calendar.py
@@ -133,9 +133,25 @@ class ExchangeCalendarEntity(
         """Return calendar events within a datetime range.
 
         Used by the calendar view and automations.
-        Queries the Exchange server directly for the requested range,
-        so both past and future events are available.
+        Prefers the coordinator cache so the calendar panel opens instantly.
+        Only falls back to a live server query when the cache is empty or
+        the requested range lies outside the cached window.
         """
+        # Try the coordinator cache first – fast, no network round-trip.
+        data = self.coordinator.data or {}
+        cached = data.get(self._calendar_key, [])
+        events: list[CalendarEvent] = []
+        for ev in cached:
+            start_dt = self._to_comparable_datetime(ev["start"])
+            end_dt = self._to_comparable_datetime(ev["end"])
+            if end_dt > start_date and start_dt < end_date:
+                events.append(self._to_calendar_event(ev))
+
+        # If the cache already covers this range we are done.
+        if events:
+            return events
+
+        # Cache empty or stale for this view – query the server directly.
         try:
             raw_events = await hass.async_add_executor_job(
                 partial(
@@ -145,18 +161,15 @@ class ExchangeCalendarEntity(
                     calendar_id=self._calendar_id,
                 )
             )
-        except Exception:
-            _LOGGER.debug(
-                "Direct range query failed, falling back to coordinator cache"
+        except Exception as err:
+            _LOGGER.warning(
+                "Direct range query failed for %s: %s", self.entity_id, err,
             )
-            data = self.coordinator.data or {}
-            raw_events = data.get(self._calendar_key, [])
+            return events  # Return whatever we got from cache (may be empty)
 
-        events = []
         for ev in raw_events:
             start_dt = self._to_comparable_datetime(ev["start"])
             end_dt = self._to_comparable_datetime(ev["end"])
-
             if end_dt > start_date and start_dt < end_date:
                 events.append(self._to_calendar_event(ev))
 

--- a/custom_components/exchange_calendar/coordinator.py
+++ b/custom_components/exchange_calendar/coordinator.py
@@ -96,7 +96,9 @@ class ExchangeCalendarCoordinator(
     async def _async_update_data(self) -> dict[str, list[dict[str, Any]]]:
         """Fetch events for each selected calendar.
 
-        exchangelib is synchronous, so we run it via async_add_executor_job.
+        Uses a double-buffer strategy: start from the existing cache and
+        overwrite entries only when the server responds successfully.
+        This prevents flickering (empty calendar) on transient errors.
         """
         await self._async_discover_calendars()
 
@@ -108,16 +110,17 @@ class ExchangeCalendarCoordinator(
         )
 
         keys = self._selected_calendar_keys()
-        result: dict[str, list[dict[str, Any]]] = {}
-        connection_errors = 0
-        last_conn_err: Exception | None = None
+        # Start with a copy of the previous data so stale entries survive.
+        new_data: dict[str, list[dict[str, Any]]] = dict(self.data or {})
+        all_failed = True
 
         for key in keys:
             calendar_id = None if key == DEFAULT_CALENDAR_KEY else key
             try:
-                result[key] = await self.hass.async_add_executor_job(
+                new_data[key] = await self.hass.async_add_executor_job(
                     self.client.get_events, days, max_events, calendar_id
                 )
+                all_failed = False
             except ExchangeAuthError as err:
                 # Trigger the reauth flow so the user can update the (likely
                 # expired) password without removing the integration.
@@ -125,20 +128,15 @@ class ExchangeCalendarCoordinator(
                     f"Exchange authentication error: {err}"
                 ) from err
             except ExchangeConnectionError as err:
-                # One unreachable calendar should not fail the whole refresh.
+                # Keep the stale entry in new_data; do not overwrite it.
                 _LOGGER.warning("Failed to fetch calendar '%s': %s", key, err)
-                result[key] = []
-                connection_errors += 1
-                last_conn_err = err
             except Exception as err:
                 _LOGGER.exception("Unexpected error fetching Exchange events")
                 raise UpdateFailed(f"Unexpected error: {err}") from err
 
-        # If every selected calendar was unreachable, treat it as a refresh
-        # failure so the entities become unavailable instead of showing empty.
-        if keys and connection_errors == len(keys):
-            raise UpdateFailed(
-                f"Exchange server unreachable: {last_conn_err}"
+        if keys and all_failed:
+            _LOGGER.warning(
+                "All selected calendars were unreachable, keeping stale data.",
             )
 
-        return result
+        return new_data

--- a/custom_components/exchange_calendar/exchange_client.py
+++ b/custom_components/exchange_calendar/exchange_client.py
@@ -524,8 +524,7 @@ class ExchangeClient:
             return date(ews_dt.year, ews_dt.month, ews_dt.day)
         return ews_dt
 
-    @staticmethod
-    def _convert_calendar_item(item: CalendarItem) -> dict[str, Any]:
+    def _convert_calendar_item(self, item: CalendarItem) -> dict[str, Any]:
         """Convert exchangelib CalendarItem to dict.
 
         Field mapping from MMM-Exchange parseXmlResponse():
@@ -534,7 +533,14 @@ class ExchangeClient:
           end -> end
           location -> location
           organizer -> organizer (stored separately)
+
+        If the server does not provide a timezone for a field, it is
+        interpreted in the mailbox's default timezone so that conversion
+        to Home Assistant local time works correctly.
         """
+        account = self._ensure_connected()
+        default_tz = account.default_timezone
+
         if item.is_all_day:
             start = item.start
             end = item.end
@@ -554,6 +560,12 @@ class ExchangeClient:
         else:
             start = ExchangeClient._to_python_dt(item.start)
             end = ExchangeClient._to_python_dt(item.end)
+            # Fallback: if the server omitted timezone info, use the
+            # mailbox's default timezone instead of assuming HA local time.
+            if isinstance(start, datetime) and start.tzinfo is None:
+                start = start.replace(tzinfo=default_tz)
+            if isinstance(end, datetime) and end.tzinfo is None:
+                end = end.replace(tzinfo=default_tz)
 
         organizer_name = ""
         if item.organizer:

--- a/custom_components/exchange_calendar/manifest.json
+++ b/custom_components/exchange_calendar/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bohemtucsok/homeassistant-exchange-calendar/issues",
   "requirements": ["exchangelib==5.6.0"],
-  "version": "2.1.0-beta.1"
+  "version": "2.1.0-beta.3"
 }

--- a/custom_components/exchange_calendar/manifest.json
+++ b/custom_components/exchange_calendar/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bohemtucsok/homeassistant-exchange-calendar/issues",
   "requirements": ["exchangelib==5.6.0"],
-  "version": "2.1.0-beta.3"
+  "version": "2.1.0-beta.4"
 }


### PR DESCRIPTION
### Problems

1. **Calendar flickering (unavailable/empty cycling)** — On every `DataUpdateCoordinator` refresh a new empty dict was created. If the Exchange server (`cas.rt.ru`) responded slowly or threw a `TransportError`, events were replaced with `[]`. On the next successful refresh they re-appeared. Result: entity toggled between available and empty every 15 minutes.

2. **Slow calendar panel** — `async_get_events()` (called whenever any calendar card is opened) **always** hit the Exchange server directly via `get_events_range`, completely ignoring the coordinator cache. Request took 20–50 seconds.

3. **Timezone warning** — The server returned an empty `_start_timezone` (`''`), causing a `UserWarning` from `exchangelib` and potentially breaking event parsing.

### Fixes

| Problem | File | Change |
|---|---|---|
| Flickering | `coordinator.py` | **Double-buffer:** old data is **preserved** on server error. `new_data = dict(self.data or {})`, only overwrite on success. |
| Slow UI | `calendar.py` | `async_get_events()` now reads from the coordinator cache **first** (`coordinator.data`). Live server query is only a fallback. |
| Timezone | `exchange_client.py` | Removed hardcoded `MS_TIMEZONE_TO_IANA_MAP[""] = "Europe/Moscow"`. `_convert_calendar_item()` now falls back to `account.default_timezone` for naive datetimes. |

### How to test

1. Set up the integration with an Exchange server that occasionally times out.
2. Wait a few refresh cycles (default interval 15 min).
3. Verify the calendar **does not flicker** (does not become empty/unavailable).
4. Open the Calendar panel — it should load **instantly**.
5. Check logs — no `UserWarning` about `_start_timezone`.

### Checklist

- [x] `coordinator.py` — double-buffer, stale-data preservation
- [x] `calendar.py` — cache-first in `async_get_events`
- [x] `exchange_client.py` — `account.default_timezone` fallback
- [x] `manifest.json` — bump version to `2.1.0-beta.4`
- [ ] Tests (none exist)
- [ ] Translations — not required

### Related issues

- Flickering calendar entity after CBA authentication
- Slow calendar panel loading
- exchangelib timezone warning on empty `_start_timezone`
